### PR TITLE
Add repository field to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "dev": "microbundle watch",
     "prepublishOnly": "yarn clean && yarn build"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sammccord/perge.git"
+  },
   "dependencies": {
     "automerge": "^0.12.1",
     "peerjs": "^1.1.0"


### PR DESCRIPTION
Makes the repo easier to find from https://www.npmjs.com/package/perge